### PR TITLE
Dev/improving sdk

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@sherrylinks/sdk",
-  "version": "0.7.0-alpha.1",
+  "version": "0.9.0-alpha.1",
   "description": "SDK for Sherry Links",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/src/interface/blockchainAction.ts
+++ b/src/interface/blockchainAction.ts
@@ -3,6 +3,10 @@ import { ContractFunctionName } from "./index";
 import { ChainId } from "./chains";
 
 // This interface is used for DEVs to define the metadata of a blockchain action
+// Amount will be transfered to the contract
+// be aware that the amount is in WEI
+// be aware that the function should be payable in the contract
+// be aware to have a mechanism to transfer that amount to the contract
 export interface BlockchainActionMetadata {
   label: string;
   contractAddress: `0x${string}`;

--- a/src/interface/blockchainAction.ts
+++ b/src/interface/blockchainAction.ts
@@ -12,7 +12,7 @@ export interface BlockchainActionMetadata {
   contractAddress: `0x${string}`;
   contractABI: Abi;
   functionName: ContractFunctionName;
-  amount?: string; // Optional for DEVs to define the amount of the transaction - msg.value to be sent
+  amount?: number; // Optional for DEVs to define the amount of the transaction - msg.value to be sent
   functionParamsLabel?: string[]; // Optional for DEVs to define the label of the parameters
   functionParamsValue?: (string | number | bigint | null | boolean)[]; // Optional for DEVs to define the value of the parameters
   chainId: ChainId;
@@ -22,6 +22,13 @@ export interface BlockchainActionMetadata {
 export interface BlockchainAction extends BlockchainActionMetadata {
   transactionParameters: AbiParameter[];
   blockchainActionType: AbiStateMutability;
+}
+
+export interface TransferActionMetadata {
+  label: string;
+  recipientAddress?: `0x${string}`;
+  amount?: number;
+  chainId: ChainId;
 }
 
 

--- a/src/interface/chains.ts
+++ b/src/interface/chains.ts
@@ -1,2 +1,2 @@
 
-export type ChainId = "fuji" | "avalanche" 
+export type ChainId = "fuji" | "avalanche" | "alfajores" | "celo"

--- a/src/interface/metadata.ts
+++ b/src/interface/metadata.ts
@@ -1,4 +1,8 @@
-import { BlockchainAction, BlockchainActionMetadata } from "./blockchainAction";
+import {
+  BlockchainAction,
+  BlockchainActionMetadata,
+  TransferActionMetadata
+} from "./blockchainAction";
 /**
  * Defines the type of action that can be performed.
  * - "action": Represents a blockchain action.
@@ -45,7 +49,7 @@ export interface Metadata {
    * The actions that can be performed by the mini app.
    * This is an array of `BlockchainAction` objects, each defining a specific action.
    */
-  actions: BlockchainActionMetadata[];
+  actions: (BlockchainActionMetadata | TransferActionMetadata)[];
 }
 
 /**
@@ -87,5 +91,5 @@ export interface Metadata {
  * ```
  */
 export interface ValidatedMetadata extends Omit<Metadata, 'actions'> {
-  actions: BlockchainAction[];
+  actions: (BlockchainAction | TransferActionMetadata )[];
 }

--- a/test/BlockchainAction.test.ts
+++ b/test/BlockchainAction.test.ts
@@ -2,6 +2,7 @@ import { describe, expect, it } from "@jest/globals";
 import {
   BlockchainActionMetadata,
   BlockchainAction,
+  TransferActionMetadata
 } from "../src/interface/blockchainAction";
 import {
   getParameters,
@@ -23,6 +24,14 @@ describe('BlockchainAction Functions', () => {
     functionParamsValue: ["0x1234567890abcdef1234567890abcdef12345678"],
     chainId: "fuji",
   };
+
+  const actionTransfer: TransferActionMetadata = { 
+    label: "Test Action",
+    chainId: "fuji",
+    recipientAddress: "0x1234567890abcdef1234567890abcdef12345678",
+    amount: 1000000000000000000,
+  }
+
 
 
   it('should get parameters of a function', () => {

--- a/test/guards.test.ts
+++ b/test/guards.test.ts
@@ -1,0 +1,25 @@
+import {
+    BlockchainActionMetadata,
+    TransferActionMetadata
+} from "../src/interface/blockchainAction";
+import {
+    isTransferActionMetadata
+} from "../src/utils/helpers";
+import { describe, expect, it } from "@jest/globals";
+
+describe("Type Guards", () => {
+    it("should identify TransferActionMetadata", () => {
+        const action: TransferActionMetadata = {
+            label: "Transfer Action",
+            chainId: "avalanche",
+            recipientAddress: "0xabcdefabcdefabcdefabcdefabcdefabcdef",
+            amount: 1000
+        };
+
+        expect(isTransferActionMetadata(action)).toBe(true);
+    });
+
+
+
+
+});


### PR DESCRIPTION
This pull request includes several changes to the `@sherrylinks/sdk` package, primarily focused on adding support for transfer actions and updating the version. The most important changes include updating the package version, adding a new interface for transfer actions, and modifying existing interfaces and functions to accommodate the new transfer actions.

Version update:

* [`package.json`](diffhunk://#diff-7ae45ad102eab3b6d7e7896acd08c427a9b25b346470d7bc6507b6481575d519L3-R3): Updated the package version from `0.7.0-alpha.1` to `0.9.0-alpha.1`.

Support for transfer actions:

* [`src/interface/blockchainAction.ts`](diffhunk://#diff-0aa9981d6973a8b61984fc4cec417366e935a9d0b624f267487de41937705560R6-R15): Added a new `TransferActionMetadata` interface and updated the `BlockchainActionMetadata` interface to use `number` instead of `string` for the `amount` field. [[1]](diffhunk://#diff-0aa9981d6973a8b61984fc4cec417366e935a9d0b624f267487de41937705560R6-R15) [[2]](diffhunk://#diff-0aa9981d6973a8b61984fc4cec417366e935a9d0b624f267487de41937705560R27-R33)
* [`src/interface/metadata.ts`](diffhunk://#diff-954de73748f888dc60208487df15c44d82049ed1aaf2e63d26464c8627222f93L1-R5): Updated the `Metadata` and `ValidatedMetadata` interfaces to include `TransferActionMetadata` in the `actions` array. [[1]](diffhunk://#diff-954de73748f888dc60208487df15c44d82049ed1aaf2e63d26464c8627222f93L1-R5) [[2]](diffhunk://#diff-954de73748f888dc60208487df15c44d82049ed1aaf2e63d26464c8627222f93L48-R52) [[3]](diffhunk://#diff-954de73748f888dc60208487df15c44d82049ed1aaf2e63d26464c8627222f93L90-R94)
* [`src/utils/helpers.ts`](diffhunk://#diff-d9b0865f2e8f841410cd4faf3e1e4a1fb7cb0b545f583f6adaad5841d7eaa58dL11-R15): Added type guards for `TransferActionMetadata` and updated the `createMetadata` and `validateMetadata` functions to handle transfer actions. [[1]](diffhunk://#diff-d9b0865f2e8f841410cd4faf3e1e4a1fb7cb0b545f583f6adaad5841d7eaa58dL11-R15) [[2]](diffhunk://#diff-d9b0865f2e8f841410cd4faf3e1e4a1fb7cb0b545f583f6adaad5841d7eaa58dL98-R111) [[3]](diffhunk://#diff-d9b0865f2e8f841410cd4faf3e1e4a1fb7cb0b545f583f6adaad5841d7eaa58dR134-R140) [[4]](diffhunk://#diff-d9b0865f2e8f841410cd4faf3e1e4a1fb7cb0b545f583f6adaad5841d7eaa58dR215-R261)

Chain ID support:

* [`src/interface/chains.ts`](diffhunk://#diff-080d2c3b24065a67d3d8973c1da34ca995f0529ac5021b17b931878cdc21d193L2-R2): Added `alfajores` and `celo` to the `ChainId` type.

Testing:

* [`test/BlockchainAction.test.ts`](diffhunk://#diff-2e215d40251aba43bdb2761848b4a9ab957be44cfc4a29ec14c63acf0b14413fR5): Added tests for `TransferActionMetadata` in the `BlockchainAction` functions test suite. [[1]](diffhunk://#diff-2e215d40251aba43bdb2761848b4a9ab957be44cfc4a29ec14c63acf0b14413fR5) [[2]](diffhunk://#diff-2e215d40251aba43bdb2761848b4a9ab957be44cfc4a29ec14c63acf0b14413fR28-R35)
* [`test/guards.test.ts`](diffhunk://#diff-a1c1c3561050b0215839b1cf0d55da25ddb9c8a1f7c9d5f6df6500248623804dR1-R25): Added tests for the `isTransferActionMetadata` type guard.