### PR TITLE
ci/cd: setting up config

### DIFF
--- a/.github/workflows/format.yml
+++ b/.github/workflows/format.yml
@@ -18,7 +18,7 @@ jobs:
       - name: Use Node.js
         uses: actions/setup-node@v3
         with:
-          node-version: '16.x'
+          node-version: '18.x'
           cache: 'yarn'
 
       - name: Install dependencies

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -12,7 +12,7 @@ jobs:
 
     strategy:
       matrix:
-        node-version: [16.x, 18.x]
+        node-version: [18.x, 20.x]
 
     steps:
       - uses: actions/checkout@v3


### PR DESCRIPTION
This pull request includes updates to the Node.js versions used in the GitHub Actions workflows for formatting and testing.

Node.js version updates:

* [`.github/workflows/format.yml`](diffhunk://#diff-173f5db567f8459284c719180df8c27debad26456e63f98c5b87d94cf87e049bL21-R21): Updated the Node.js version from `16.x` to `18.x` for the formatting job.
* [`.github/workflows/test.yml`](diffhunk://#diff-faff1af3d8ff408964a57b2e475f69a6b7c7b71c9978cccc8f471798caac2c88L15-R15): Updated the Node.js versions from `16.x, 18.x` to `18.x, 20.x` for the testing job.