### PR TITLE
ci/cd: improving integration

### DIFF
--- a/.github/workflows/format.yml
+++ b/.github/workflows/format.yml
@@ -2,9 +2,9 @@ name: Format Code
 
 on:
   push:
-    branches: [main, staging]
+    branches: [main, staging, develop]
   pull_request:
-    branches: [main, staging]
+    branches: [main, staging, develop]
 
 jobs:
   format:
@@ -25,7 +25,8 @@ jobs:
         run: yarn install --frozen-lockfile
 
       - name: Format with Prettier
-        run: yarn prettier --write .
+        # Usa npx para ejecutar prettier directamente
+        run: npx prettier --write .
 
       - name: Commit changes
         uses: stefanzweifel/git-auto-commit-action@v4

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -2,9 +2,9 @@ name: Run Tests
 
 on:
   push:
-    branches: [main, staging]
+    branches: [main, staging, develop]
   pull_request:
-    branches: [main, staging]
+    branches: [main, staging, develop]
 
 jobs:
   test:


### PR DESCRIPTION
This pull request includes updates to the GitHub Actions workflows for formatting code and running tests. The changes primarily focus on adding the `develop` branch to the list of branches that trigger these workflows and modifying how Prettier is executed.

Changes to GitHub Actions workflows:

* [`.github/workflows/format.yml`](diffhunk://#diff-173f5db567f8459284c719180df8c27debad26456e63f98c5b87d94cf87e049bL5-R7): Added the `develop` branch to the list of branches that trigger the format workflow.
* [`.github/workflows/format.yml`](diffhunk://#diff-173f5db567f8459284c719180df8c27debad26456e63f98c5b87d94cf87e049bL28-R29): Modified the format job to use `npx` for running Prettier directly instead of using `yarn`.
* [`.github/workflows/test.yml`](diffhunk://#diff-faff1af3d8ff408964a57b2e475f69a6b7c7b71c9978cccc8f471798caac2c88L5-R7): Added the `develop` branch to the list of branches that trigger the test workflow.