### PR TITLE
Corregie workflows de GitHub para manejar problemas de referencia de ramas

### DIFF
--- a/.github/workflows/format.yml
+++ b/.github/workflows/format.yml
@@ -13,7 +13,8 @@ jobs:
       - uses: actions/checkout@v3
         with:
           # Make sure the actual branch is checked out when running on pull requests
-          ref: ${{ github.head_ref }}
+          ref: ${{ github.head_ref || github.ref_name }}
+          fetch-depth: 0
 
       - name: Use Node.js
         uses: actions/setup-node@v3
@@ -32,4 +33,4 @@ jobs:
         uses: stefanzweifel/git-auto-commit-action@v4
         with:
           commit_message: 'style: apply prettier formatting'
-          branch: ${{ github.head_ref }}
+          branch: ${{ github.head_ref || github.ref_name }}

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -16,6 +16,9 @@ jobs:
 
     steps:
       - uses: actions/checkout@v3
+        with:
+          ref: ${{ github.head_ref || github.ref_name }}
+          fetch-depth: 0
 
       - name: Use Node.js ${{ matrix.node-version }}
         uses: actions/setup-node@v3


### PR DESCRIPTION
## Cambios realizados

- [ ] feat: -
- [x] fix: corrige workflows de GitHub para manejar problemas de referencia de ramas
- [ ] docs: -
- [ ] style: -
- [ ] refactor: -
- [ ] perf: -
- [ ] test: -
- [ ] build: -
- [ ] chore: -
- [ ] revert: -

## Describir los cambios

Este pull request mejora los workflows de GitHub Actions para resolver problemas con las referencias a ramas en el proceso de CI/CD.

### Mejoras en CI/CD:
* Se ha modificado la configuración del checkout en los workflows para manejar correctamente las referencias de ramas
* Se implementó un fallback usando `github.ref_name` cuando `github.head_ref` no está disponible
* Se añadió `fetch-depth: 0` para garantizar que se obtenga un historial completo durante el proceso de checkout
* Se actualizaron ambos workflows (format.yml y test.yml) con la misma configuración para mantener la consistencia

## Problemas relacionados (Issues)

Ninguno.

## Elementos visuales (opcional)

```
Error en workflow antes de los cambios:
El proceso '/usr/bin/git' falló con el código de salida 1 mientras intentaba obtener la rama
```

## Lista de verificación

- [x] Mi código sigue el estilo de código de este proyecto.
- [ ] Mi cambio requiere un cambio en la documentación.
- [ ] He actualizado la documentación en consecuencia.
