### PR TITLE
docs: add youtube tutorial `iframe` for guide pages

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,24 +8,37 @@
 
 ## 🌟 Overview
 
-Sherry SDK is a powerful toolkit for building interactive Web3 mini-apps that can be embedded within social media posts. The SDK enables developers to create rich, composable blockchain experiences without requiring users to leave their social media feed.
+Sherry SDK is a powerful toolkit for building interactive Web3 mini-apps that
+can be embedded within social media posts and platforms. The SDK enables
+developers to create rich, composable blockchain experiences without requiring
+users to leave their social media feed.
 
-With Sherry, you can transform any post into an interactive dApp that allows users to swap tokens, vote on proposals, mint NFTs, sign transactions, and much more - all with built-in validation and a unified experience across chains.
+With Sherry, you can transform any post into an interactive dApp that allows
+users to swap tokens, vote on proposals, mint NFTs, sign transactions, and much
+more - all with built-in validation and a unified experience across chains.
 
 ## ✨ Features
 
-- 🔗 **Multi-chain Support**: Build once, deploy across Ethereum, Avalanche, Celo, Monad, and more
+- 🔗 **Multi-chain Support**: Build once, deploy across Ethereum, Avalanche,
+  Celo, and more
 - 🧩 **Multiple Action Types**:
-  - **Blockchain Actions**: Call smart contract functions with rich parameter configuration
-  - **Transfer Actions**: Enable token transfers with customizable UIs
-  - **HTTP Actions**: Make API calls and form submissions
-  - **Nested Action Flows**: Create interactive multi-step processes with conditional paths
-- 📋 **Built-in Validation**: Ensure your mini-apps are valid and well-formed before deployment
-- ⚡ **Type Safety**: Full TypeScript support with comprehensive type definitions
-- 🔄 **Cross-chain Interactions**: Enable transactions across multiple blockchains
-- 📊 **Metadata Templates**: Ready-to-use templates for common Web3 use cases
-- 💻 **Developer Tools**: Built-in metadata analysis and action transformation utilities
-- 📱 **User-friendly Parameter Configuration**: Flexible UI specifications for better user experience
+  - **Transfer Actions**: Native token transfers with customizable UIs
+  - **Blockchain Actions**: Smart contract interactions with rich parameter
+    configuration
+  - **Dynamic Actions**: Server-side logic with HTTP endpoints
+  - **Nested Action Flows**: Interactive multi-step processes with conditional
+    paths
+- 📋 **Built-in Validation**: Ensure your mini-apps are valid and well-formed
+  before deployment
+- ⚡ **Type Safety**: Full TypeScript support with comprehensive type
+  definitions
+- 🔄 **Cross-chain Interactions**: Enable transactions across multiple
+  blockchains
+- 📊 **Rich Parameter Types**: Select dropdowns, radio buttons, text inputs, and
+  more
+- 💻 **Developer Tools**: Built-in metadata analysis and debugging utilities
+- 📱 **Responsive Design**: Mini-apps that work across all platforms and screen
+  sizes
 
 ## 📦 Installation
 
@@ -44,21 +57,21 @@ yarn add @sherrylinks/sdk
 ### Basic Mini-App
 
 ```typescript
-import { createMetadata, Metadata } from '@sherrylinks/sdk';
+import { createMetadata, Metadata } from "@sherrylinks/sdk";
 
 // Create a simple token transfer metadata
 const metadata: Metadata = {
-  url: 'https://myapp.example',
-  icon: 'https://example.com/icon.png',
-  title: 'Send AVAX',
-  description: 'Quick AVAX transfer',
+  url: "https://myapp.example",
+  icon: "https://example.com/icon.png",
+  title: "Send AVAX",
+  description: "Quick AVAX transfer",
   actions: [
     {
-      label: 'Send 0.1 AVAX',
-      description: 'Transfer 0.1 AVAX to recipient',
-      to: '0x1234567890123456789012345678901234567890',
+      label: "Send 0.1 AVAX",
+      description: "Transfer 0.1 AVAX to recipient",
+      to: "0x1234567890123456789012345678901234567890",
       amount: 0.1,
-      chains: { source: 'avalanche' },
+      chains: { source: "avalanche" },
     },
   ],
 };
@@ -70,90 +83,98 @@ const validatedMetadata = createMetadata(metadata);
 ### Nested Action Flow
 
 ```typescript
-import { createMetadata, Metadata, ActionFlow } from '@sherrylinks/sdk';
+import { ActionFlow, createMetadata, Metadata } from "@sherrylinks/sdk";
 
 // Create a flow with multiple steps and decision points
 const swapFlow: ActionFlow = {
-  type: 'flow',
-  label: 'Token Swap',
-  initialActionId: 'select-tokens',
+  type: "flow",
+  label: "Token Swap",
+  initialActionId: "select-tokens",
   actions: [
     // Step 1: Select tokens and amount
     {
-      id: 'select-tokens',
-      type: 'http',
-      label: 'Select Tokens',
-      path: 'https://api.example.com/quote',
+      id: "select-tokens",
+      type: "http",
+      label: "Select Tokens",
+      path: "https://api.example.com/quote",
       params: [
         // Token selection parameters...
       ],
-      nextActions: [{ actionId: 'review-quote' }],
+      nextActions: [{ actionId: "review-quote" }],
     },
 
     // Step 2: Review and decide
     {
-      id: 'review-quote',
-      type: 'decision',
-      label: 'Review Quote',
-      title: 'Review Your Swap',
+      id: "review-quote",
+      type: "decision",
+      label: "Review Quote",
+      title: "Review Your Swap",
       options: [
-        { label: 'Confirm', value: 'confirm', nextActionId: 'execute-swap' },
-        { label: 'Cancel', value: 'cancel', nextActionId: 'cancelled' },
+        { label: "Confirm", value: "confirm", nextActionId: "execute-swap" },
+        { label: "Cancel", value: "cancel", nextActionId: "cancelled" },
       ],
     },
 
     // Step 3: Execute swap
     {
-      id: 'execute-swap',
-      type: 'blockchain',
-      label: 'Swap Tokens',
-      address: '0xRouterAddress',
+      id: "execute-swap",
+      type: "blockchain",
+      label: "Swap Tokens",
+      address: "0xRouterAddress",
       // ... other blockchain action properties
       nextActions: [
         {
-          actionId: 'success',
-          conditions: [{ field: 'lastResult.status', operator: 'eq', value: 'success' }],
+          actionId: "success",
+          conditions: [{
+            field: "lastResult.status",
+            operator: "eq",
+            value: "success",
+          }],
         },
         {
-          actionId: 'failed',
-          conditions: [{ field: 'lastResult.status', operator: 'eq', value: 'error' }],
+          actionId: "failed",
+          conditions: [{
+            field: "lastResult.status",
+            operator: "eq",
+            value: "error",
+          }],
         },
       ],
     },
 
     // Completion states
     {
-      id: 'success',
-      type: 'completion',
-      label: 'Swap Complete',
-      message: 'Your swap was successful!',
-      status: 'success',
+      id: "success",
+      type: "completion",
+      label: "Swap Complete",
+      message: "Your swap was successful!",
+      status: "success",
     },
 
     {
-      id: 'failed',
-      type: 'completion',
-      label: 'Swap Failed',
-      message: 'Your swap failed. Please try again.',
-      status: 'error',
+      id: "failed",
+      type: "completion",
+      label: "Swap Failed",
+      message: "Your swap failed. Please try again.",
+      status: "error",
     },
 
     {
-      id: 'cancelled',
-      type: 'completion',
-      label: 'Swap Cancelled',
-      message: 'You cancelled the swap.',
-      status: 'info',
+      id: "cancelled",
+      type: "completion",
+      label: "Swap Cancelled",
+      message: "You cancelled the swap.",
+      status: "info",
     },
   ],
 };
 
 // Add to metadata
 const flowMetadata: Metadata = {
-  url: 'https://swap.example',
-  icon: 'https://example.com/swap-icon.png',
-  title: 'Advanced Token Swap',
-  description: 'Swap tokens with our guided flow',
+  url: "https://swap.example",
+  icon: "https://example.com/swap-icon.png",
+  title: "Advanced Token Swap",
+  description: "Swap tokens with our guided flow",
   actions: [swapFlow],
 };
 
@@ -165,7 +186,60 @@ const validatedFlow = createMetadata(flowMetadata);
 
 ### Blockchain Actions
 
-Interact with smart contract functions:
+Interact directly with smart contracts:
+
+- Call any contract function
+- Rich parameter configuration
+- Support for all Solidity types
+- Automatic gas estimation
+
+### Dynamic Actions
+
+Server-side processing with HTTP endpoints:
+
+- Custom business logic
+- External API integrations
+- Real-time data processing
+- Complex calculations and optimizations
+
+### Nested Action Flows
+
+Create multi-step interactive experiences:
+
+- Conditional branching
+- Decision points
+- Progress tracking
+- Completion states
+
+## 🌐 Supported Chains
+
+- **Ethereum Mainnet** (`ethereum`)
+- **Avalanche C-Chain** (`avalanche`)
+- **Avalanche Fuji Testnet** (`fuji`)
+- **Celo Mainnet** (`celo`)
+- **Celo Alfajores Testnet** (`alfajores`)
+
+_More chains being added regularly_
+
+## 📚 Live Examples
+
+Check out real working examples across different complexity levels:
+
+[**View All Examples →**](https://docs.sherry.social/docs/getting-started/examples)
+
+## 🔧 Development Tools
+
+### Sherry Debugger
+
+Test and validate your mini-apps during development:
+
+- **[Sherry Debugger](https://app.sherry.social/debugger)** - Interactive
+  testing environment
+- Real-time validation
+- Parameter testing
+- JSON and TypeScript input support
+
+### Validation
 
 ```typescript
 {
@@ -198,44 +272,37 @@ Interact with smart contract functions:
 
 Send native tokens or assets:
 
-```typescript
-{
-  label: 'Donate',
-  description: 'Support our project',
-  chains: { source: 'ethereum' },
+- **[English Guide](https://docs.sherry.social/docs/guides/guide-en)** -
+  Complete Next.js integration tutorial
+- **[Spanish Guide](https://docs.sherry.social/docs/guides/guide-es)** - Guía
+  completa en español para Next.js
 
-  // Fixed recipient
-  to: '0xRecipientAddress',
+  // Fixed recipient to: '0xRecipientAddress',
 
-  // Or let the user choose
-  recipient: {
-    type: 'select',
-    label: 'Select Charity',
-    options: [
-      { label: 'Education Fund', value: '0xAddress1' },
-      { label: 'Climate Action', value: '0xAddress2' }
-    ]
-  },
+- **[Quick Start](https://docs.sherry.social/docs/getting-started/quickstart)** -
+  5-minute setup
+- **[Your First Mini App](https://docs.sherry.social/docs/getting-started/creatingminiapp)** -
+  Step-by-step tutorial
+- **[Core Concepts](https://docs.sherry.social/docs/core-concepts)** -
+  Understanding the fundamentals
 
-  // Fixed amount
-  amount: 0.1,
+  // Fixed amount amount: 0.1,
 
-  // Or let the user choose
-  amountConfig: {
-    type: 'radio',
-    label: 'Donation Amount',
-    options: [
-      { label: 'Small', value: 0.01 },
-      { label: 'Medium', value: 0.05 },
-      { label: 'Large', value: 0.1 }
-    ]
-  }
-}
-```
+  // Or let the user choose amountConfig: { type: 'radio', label: 'Donation
+  Amount', options: [ { label: 'Small', value: 0.01 }, { label: 'Medium', value:
+  0.05 }, { label: 'Large', value: 0.1 } ] } }
 
+````
 ### HTTP Actions
 
-Make API calls and form submissions:
+- **🎨 NFT Collections** - Let users mint NFTs directly from social posts
+- **🔄 Token Swaps** - Enable DeFi trading without leaving social media
+- **🗳️ DAO Governance** - Streamline proposal voting and participation
+- **💰 Creator Economy** - Direct support and tipping mechanisms
+- **🏦 DeFi Integration** - Seamless access to lending, staking, and yield
+  farming
+- **🎮 Gaming** - In-game transactions and asset management
+- **🏪 Commerce** - Crypto payments and NFT marketplace integration
 
 ```typescript
 {
@@ -269,7 +336,7 @@ Make API calls and form submissions:
     }
   ]
 }
-```
+````
 
 ### Nested Action Flows
 
@@ -337,23 +404,23 @@ Create interactive, multi-step experiences with conditional paths:
 The SDK provides template helpers for common parameter types:
 
 ```typescript
-import { createParameter, PARAM_TEMPLATES } from '@sherrylinks/sdk';
+import { createParameter, PARAM_TEMPLATES } from "@sherrylinks/sdk";
 
 // Create a parameter using a template
 const emailParam = createParameter(PARAM_TEMPLATES.EMAIL, {
-  name: 'email',
-  label: 'Your Email',
+  name: "email",
+  label: "Your Email",
   required: true,
 });
 
 // Create a select parameter with custom options
 const tokenParam = createParameter(PARAM_TEMPLATES.TOKEN_SELECT, {
-  name: 'token',
-  label: 'Select Token',
+  name: "token",
+  label: "Select Token",
   // Override default options
   options: [
-    { label: 'USDC', value: 'usdc' },
-    { label: 'DAI', value: 'dai' },
+    { label: "USDC", value: "usdc" },
+    { label: "DAI", value: "dai" },
   ],
 });
 ```
@@ -391,17 +458,17 @@ Check the `src/examples` directory for complete implementations.
 The SDK provides extensive validation to ensure your mini-apps work correctly:
 
 ```typescript
-import { validateMetadata } from '@sherrylinks/sdk';
+import { validateMetadata } from "@sherrylinks/sdk";
 
 // Validate metadata
 const validationResult = validateMetadata(myMetadata);
 
 if (validationResult.isValid) {
   // Ready to use!
-  console.log('Metadata is valid:', validationResult.type);
+  console.log("Metadata is valid:", validationResult.type);
 } else {
   // Handle validation errors
-  console.error('Validation errors:', validationResult.errors);
+  console.error("Validation errors:", validationResult.errors);
 }
 ```
 
@@ -439,56 +506,18 @@ yarn test --coverage
 # Build the package
 yarn build
 
-# Generate/serve documentation (run from docs/ directory)
-cd docs
-yarn start # For development server
-yarn build # To build static files
+# Start documentation server
+cd docs && yarn install && yarn start
 ```
 
 ## Browser Usage
 
-When using Sherry SDK in browser environments, you'll need to configure your bundler (Webpack, Rollup, etc.) to handle Node.js built-ins:
-
-### Webpack
-
-```javascript
-// webpack.config.js
-module.exports = {
-  // ...your other config
-  resolve: {
-    fallback: {
-      crypto: require.resolve('crypto-browserify'),
-      stream: require.resolve('stream-browserify'),
-      buffer: require.resolve('buffer/'),
-    },
-  },
-  plugins: [
-    new webpack.ProvidePlugin({
-      Buffer: ['buffer', 'Buffer'],
-    }),
-  ],
-};
-```
-
-### Vite
-
-```javascript
-// vite.config.js
-import { defineConfig } from 'vite';
-import { nodePolyfills } from 'vite-plugin-node-polyfills';
-
-export default defineConfig({
-  plugins: [
-    nodePolyfills({
-      globals: {
-        Buffer: true,
-        process: true,
-      },
-      include: ['crypto', 'stream', 'buffer'],
-    }),
-  ],
-});
-```
+- **[Documentation](https://docs.sherry.social)** - Complete guides and API
+  reference
+- **[Discord](https://discord.gg/69brTf6J)** - Community support and discussions
+- **[GitHub Issues](https://github.com/SherryLabs/sherry-sdk/issues)** - Bug
+  reports and feature requests
+- **[Twitter](https://x.com/sherryprotocol)** - Latest updates and announcements
 
 ## 🤝 Contributing
 
@@ -502,10 +531,16 @@ Contributions are welcome! Please feel free to submit a Pull Request.
 
 ## 📄 License
 
-This project is licensed under the MIT License - see the LICENSE file for details.
+This project is licensed under the MIT License - see the LICENSE file for
+details.
 
 ## 🔗 Links
 
-- [Project Website](https://sherry.social)
-- [Documentation](https://docs.sherry.social)
-- [GitHub Repository](https://github.com/SherryLabs/sherry-sdk)
+- **[Sherry Platform](https://sherry.social)** - Live platform and mini-app
+  gallery
+- **[Documentation](https://docs.sherry.social)** - Complete developer
+  documentation
+- **[GitHub Repository](https://github.com/SherryLabs/sherry-sdk)** - Source
+  code and issues
+- **[npm Package](https://www.npmjs.com/package/@sherrylinks/sdk)** - Package
+  registry

--- a/README.md
+++ b/README.md
@@ -57,21 +57,21 @@ yarn add @sherrylinks/sdk
 ### Basic Mini-App
 
 ```typescript
-import { createMetadata, Metadata } from "@sherrylinks/sdk";
+import { createMetadata, Metadata } from '@sherrylinks/sdk';
 
 // Create a simple token transfer metadata
 const metadata: Metadata = {
-  url: "https://myapp.example",
-  icon: "https://example.com/icon.png",
-  title: "Send AVAX",
-  description: "Quick AVAX transfer",
+  url: 'https://myapp.example',
+  icon: 'https://example.com/icon.png',
+  title: 'Send AVAX',
+  description: 'Quick AVAX transfer',
   actions: [
     {
-      label: "Send 0.1 AVAX",
-      description: "Transfer 0.1 AVAX to recipient",
-      to: "0x1234567890123456789012345678901234567890",
+      label: 'Send 0.1 AVAX',
+      description: 'Transfer 0.1 AVAX to recipient',
+      to: '0x1234567890123456789012345678901234567890',
       amount: 0.1,
-      chains: { source: "avalanche" },
+      chains: { source: 'avalanche' },
     },
   ],
 };
@@ -83,98 +83,102 @@ const validatedMetadata = createMetadata(metadata);
 ### Nested Action Flow
 
 ```typescript
-import { ActionFlow, createMetadata, Metadata } from "@sherrylinks/sdk";
+import { ActionFlow, createMetadata, Metadata } from '@sherrylinks/sdk';
 
 // Create a flow with multiple steps and decision points
 const swapFlow: ActionFlow = {
-  type: "flow",
-  label: "Token Swap",
-  initialActionId: "select-tokens",
+  type: 'flow',
+  label: 'Token Swap',
+  initialActionId: 'select-tokens',
   actions: [
     // Step 1: Select tokens and amount
     {
-      id: "select-tokens",
-      type: "http",
-      label: "Select Tokens",
-      path: "https://api.example.com/quote",
+      id: 'select-tokens',
+      type: 'http',
+      label: 'Select Tokens',
+      path: 'https://api.example.com/quote',
       params: [
         // Token selection parameters...
       ],
-      nextActions: [{ actionId: "review-quote" }],
+      nextActions: [{ actionId: 'review-quote' }],
     },
 
     // Step 2: Review and decide
     {
-      id: "review-quote",
-      type: "decision",
-      label: "Review Quote",
-      title: "Review Your Swap",
+      id: 'review-quote',
+      type: 'decision',
+      label: 'Review Quote',
+      title: 'Review Your Swap',
       options: [
-        { label: "Confirm", value: "confirm", nextActionId: "execute-swap" },
-        { label: "Cancel", value: "cancel", nextActionId: "cancelled" },
+        { label: 'Confirm', value: 'confirm', nextActionId: 'execute-swap' },
+        { label: 'Cancel', value: 'cancel', nextActionId: 'cancelled' },
       ],
     },
 
     // Step 3: Execute swap
     {
-      id: "execute-swap",
-      type: "blockchain",
-      label: "Swap Tokens",
-      address: "0xRouterAddress",
+      id: 'execute-swap',
+      type: 'blockchain',
+      label: 'Swap Tokens',
+      address: '0xRouterAddress',
       // ... other blockchain action properties
       nextActions: [
         {
-          actionId: "success",
-          conditions: [{
-            field: "lastResult.status",
-            operator: "eq",
-            value: "success",
-          }],
+          actionId: 'success',
+          conditions: [
+            {
+              field: 'lastResult.status',
+              operator: 'eq',
+              value: 'success',
+            },
+          ],
         },
         {
-          actionId: "failed",
-          conditions: [{
-            field: "lastResult.status",
-            operator: "eq",
-            value: "error",
-          }],
+          actionId: 'failed',
+          conditions: [
+            {
+              field: 'lastResult.status',
+              operator: 'eq',
+              value: 'error',
+            },
+          ],
         },
       ],
     },
 
     // Completion states
     {
-      id: "success",
-      type: "completion",
-      label: "Swap Complete",
-      message: "Your swap was successful!",
-      status: "success",
+      id: 'success',
+      type: 'completion',
+      label: 'Swap Complete',
+      message: 'Your swap was successful!',
+      status: 'success',
     },
 
     {
-      id: "failed",
-      type: "completion",
-      label: "Swap Failed",
-      message: "Your swap failed. Please try again.",
-      status: "error",
+      id: 'failed',
+      type: 'completion',
+      label: 'Swap Failed',
+      message: 'Your swap failed. Please try again.',
+      status: 'error',
     },
 
     {
-      id: "cancelled",
-      type: "completion",
-      label: "Swap Cancelled",
-      message: "You cancelled the swap.",
-      status: "info",
+      id: 'cancelled',
+      type: 'completion',
+      label: 'Swap Cancelled',
+      message: 'You cancelled the swap.',
+      status: 'info',
     },
   ],
 };
 
 // Add to metadata
 const flowMetadata: Metadata = {
-  url: "https://swap.example",
-  icon: "https://example.com/swap-icon.png",
-  title: "Advanced Token Swap",
-  description: "Swap tokens with our guided flow",
+  url: 'https://swap.example',
+  icon: 'https://example.com/swap-icon.png',
+  title: 'Advanced Token Swap',
+  description: 'Swap tokens with our guided flow',
   actions: [swapFlow],
 };
 
@@ -404,23 +408,23 @@ Create interactive, multi-step experiences with conditional paths:
 The SDK provides template helpers for common parameter types:
 
 ```typescript
-import { createParameter, PARAM_TEMPLATES } from "@sherrylinks/sdk";
+import { createParameter, PARAM_TEMPLATES } from '@sherrylinks/sdk';
 
 // Create a parameter using a template
 const emailParam = createParameter(PARAM_TEMPLATES.EMAIL, {
-  name: "email",
-  label: "Your Email",
+  name: 'email',
+  label: 'Your Email',
   required: true,
 });
 
 // Create a select parameter with custom options
 const tokenParam = createParameter(PARAM_TEMPLATES.TOKEN_SELECT, {
-  name: "token",
-  label: "Select Token",
+  name: 'token',
+  label: 'Select Token',
   // Override default options
   options: [
-    { label: "USDC", value: "usdc" },
-    { label: "DAI", value: "dai" },
+    { label: 'USDC', value: 'usdc' },
+    { label: 'DAI', value: 'dai' },
   ],
 });
 ```
@@ -458,17 +462,17 @@ Check the `src/examples` directory for complete implementations.
 The SDK provides extensive validation to ensure your mini-apps work correctly:
 
 ```typescript
-import { validateMetadata } from "@sherrylinks/sdk";
+import { validateMetadata } from '@sherrylinks/sdk';
 
 // Validate metadata
 const validationResult = validateMetadata(myMetadata);
 
 if (validationResult.isValid) {
   // Ready to use!
-  console.log("Metadata is valid:", validationResult.type);
+  console.log('Metadata is valid:', validationResult.type);
 } else {
   // Handle validation errors
-  console.error("Validation errors:", validationResult.errors);
+  console.error('Validation errors:', validationResult.errors);
 }
 ```
 
@@ -523,11 +527,31 @@ cd docs && yarn install && yarn start
 
 Contributions are welcome! Please feel free to submit a Pull Request.
 
-1. Fork the repository
-2. Create a feature branch (`git checkout -b feature/amazing-feature`)
-3. Commit your changes (`git commit -m 'Add amazing feature'`)
-4. Push to the branch (`git push origin feature/amazing-feature`)
-5. Open a Pull Request
+1. **Fork the repository.**
+
+2. **Clone your fork and create a new branch from `develop`:**
+
+   ```bash
+   git clone https://github.com/YOUR_USERNAME/sherry-sdk.git
+   cd sherry-sdk
+   git switch -c feature/amazing-feature develop
+   ```
+
+3. **Commit your changes:**
+
+   ```bash
+   # ...do your work...
+   git add .
+   git commit -m "feat: Add amazing feature"
+   ```
+
+4. **Push to your branch:**
+
+   ```bash
+   git push origin feature/amazing-feature
+   ```
+
+5. **Open a Pull Request** to the `develop` branch.
 
 ## 📄 License
 

--- a/docs/docs/guides/guide-en.mdx
+++ b/docs/docs/guides/guide-en.mdx
@@ -70,8 +70,8 @@ information and structure that platforms need to render your application.
 Create the file `app/api/my-app/route.ts`:
 
 ```typescript
-import { NextRequest, NextResponse } from "next/server";
-import { createMetadata, Metadata, ValidatedMetadata } from "@sherrylinks/sdk";
+import { NextRequest, NextResponse } from 'next/server';
+import { createMetadata, Metadata, ValidatedMetadata } from '@sherrylinks/sdk';
 ```
 
 ### 2. Configure General Information
@@ -116,11 +116,11 @@ const metadata: Metadata = {
   // ... previous general information ...
   actions: [
     {
-      type: "dynamic", // Action type (always "dynamic" for mini apps)
-      label: "Execute Action", // Text that will appear on the button
-      description: "Description of what this specific action does",
+      type: 'dynamic', // Action type (always "dynamic" for mini apps)
+      label: 'Execute Action', // Text that will appear on the button
+      description: 'Description of what this specific action does',
       chains: {
-        source: "fuji", // Blockchain where it will execute (fuji = Avalanche Fuji Testnet)
+        source: 'fuji', // Blockchain where it will execute (fuji = Avalanche Fuji Testnet)
       },
       path: `/api/my-app`, // Path of the POST endpoint that will handle execution
       // Parameters will be defined in the next step
@@ -150,18 +150,18 @@ const metadata: Metadata = {
       // ... previous configuration ...
       params: [
         {
-          name: "message", // Parameter name (will be used as query param)
-          label: "Your Message", // Label that the user will see
-          type: "text", // Input type (text, number, email, etc.)
+          name: 'message', // Parameter name (will be used as query param)
+          label: 'Your Message', // Label that the user will see
+          type: 'text', // Input type (text, number, email, etc.)
           required: true, // Whether it's mandatory or not
-          description: "Enter the message you want to store on the blockchain",
+          description: 'Enter the message you want to store on the blockchain',
         },
         {
-          name: "amount",
-          label: "Amount (ETH)",
-          type: "number",
+          name: 'amount',
+          label: 'Amount (ETH)',
+          type: 'number',
           required: false,
-          description: "Amount in ETH (optional)",
+          description: 'Amount in ETH (optional)',
         },
       ],
     },
@@ -191,15 +191,18 @@ export async function GET(req: NextRequest) {
     // Return with CORS headers
     return NextResponse.json(validated, {
       headers: {
-        "Access-Control-Allow-Origin": "*",
-        "Access-Control-Allow-Methods": "GET, POST, PUT, DELETE, OPTIONS",
+        'Access-Control-Allow-Origin': '*',
+        'Access-Control-Allow-Methods': 'GET, POST, PUT, DELETE, OPTIONS',
       },
     });
   } catch (error) {
-    console.error("Error creating metadata:", error);
-    return NextResponse.json({ error: "Failed to create metadata" }, {
-      status: 500,
-    });
+    console.error('Error creating metadata:', error);
+    return NextResponse.json(
+      { error: 'Failed to create metadata' },
+      {
+        status: 500,
+      },
+    );
   }
 }
 ```
@@ -243,12 +246,12 @@ export async function POST(req: NextRequest) {
 
 ```typescript
 // Process data (you can add your business logic here)
-console.log("Message received:", message);
-console.log("Amount received:", amount);
+console.log('Message received:', message);
+console.log('Amount received:', amount);
 
 // Create transaction
 const tx = {
-  to: "0x5ee75a1B1648C023e885E58bD3735Ae273f2cc52", // Destination address
+  to: '0x5ee75a1B1648C023e885E58bD3735Ae273f2cc52', // Destination address
   value: BigInt(amount ? parseFloat(amount) * 1e18 : 1000000), // Value in wei
   chainId: avalancheFuji.id, // Blockchain ID
   // data: "0x..." // You can add contract data here
@@ -296,10 +299,10 @@ export async function OPTIONS(request: NextRequest) {
   return new NextResponse(null, {
     status: 204,
     headers: {
-      "Access-Control-Allow-Origin": "*",
-      "Access-Control-Allow-Methods": "GET, POST, PUT, DELETE, OPTIONS",
-      "Access-Control-Allow-Headers":
-        "Content-Type, Authorization, X-CSRF-Token, X-Requested-With, Accept",
+      'Access-Control-Allow-Origin': '*',
+      'Access-Control-Allow-Methods': 'GET, POST, PUT, DELETE, OPTIONS',
+      'Access-Control-Allow-Headers':
+        'Content-Type, Authorization, X-CSRF-Token, X-Requested-With, Accept',
     },
   });
 }

--- a/docs/docs/guides/guide-en.mdx
+++ b/docs/docs/guides/guide-en.mdx
@@ -1,6 +1,17 @@
 # Creating Mini Apps with Next.js and Sherry SDK
 
-This guide will teach you step by step how to create a mini app using Next.js and the Sherry Links SDK. Mini apps are dynamic applications that can be integrated into different platforms and allow users to interact with smart contracts in a simple way.
+<iframe
+  style={{ width: '100%', aspectRatio: '16 / 9', border: 'none' }}
+  src="https://www.youtube.com/embed/Aq6gqxjEoxo"
+  title="YouTube video player"
+  allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture; web-share"
+  allowfullscreen
+></iframe>
+
+This guide will teach you step by step how to create a mini app using Next.js
+and the Sherry Links SDK. Mini apps are dynamic applications that can be
+integrated into different platforms and allow users to interact with smart
+contracts in a simple way.
 
 ## Table of Contents
 
@@ -51,15 +62,16 @@ module.exports = nextConfig;
 
 ## Creating the GET Endpoint - Metadata
 
-The GET endpoint is the heart of your mini app. Here you define all the information and structure that platforms need to render your application.
+The GET endpoint is the heart of your mini app. Here you define all the
+information and structure that platforms need to render your application.
 
 ### 1. Create the Route File
 
 Create the file `app/api/my-app/route.ts`:
 
 ```typescript
-import { NextRequest, NextResponse } from 'next/server';
-import { createMetadata, Metadata, ValidatedMetadata } from '@sherrylinks/sdk';
+import { NextRequest, NextResponse } from "next/server";
+import { createMetadata, Metadata, ValidatedMetadata } from "@sherrylinks/sdk";
 ```
 
 ### 2. Configure General Information
@@ -89,7 +101,8 @@ export async function GET(req: NextRequest) {
 #### General Fields Explanation:
 
 - **url**: URL of your main website or documentation
-- **icon**: Image that will represent your mini app (must be publicly accessible)
+- **icon**: Image that will represent your mini app (must be publicly
+  accessible)
 - **title**: Short and descriptive name of your application
 - **baseUrl**: URL where your application is running (automatically constructed)
 - **description**: Clear explanation of what your mini app does
@@ -103,11 +116,11 @@ const metadata: Metadata = {
   // ... previous general information ...
   actions: [
     {
-      type: 'dynamic', // Action type (always "dynamic" for mini apps)
-      label: 'Execute Action', // Text that will appear on the button
-      description: 'Description of what this specific action does',
+      type: "dynamic", // Action type (always "dynamic" for mini apps)
+      label: "Execute Action", // Text that will appear on the button
+      description: "Description of what this specific action does",
       chains: {
-        source: 'fuji', // Blockchain where it will execute (fuji = Avalanche Fuji Testnet)
+        source: "fuji", // Blockchain where it will execute (fuji = Avalanche Fuji Testnet)
       },
       path: `/api/my-app`, // Path of the POST endpoint that will handle execution
       // Parameters will be defined in the next step
@@ -126,7 +139,8 @@ const metadata: Metadata = {
 
 ### 4. Configure Parameters
 
-Parameters are the data that the user must provide. If they don't have a default value, an input will be rendered:
+Parameters are the data that the user must provide. If they don't have a default
+value, an input will be rendered:
 
 ```typescript
 const metadata: Metadata = {
@@ -136,18 +150,18 @@ const metadata: Metadata = {
       // ... previous configuration ...
       params: [
         {
-          name: 'message', // Parameter name (will be used as query param)
-          label: 'Your Message', // Label that the user will see
-          type: 'text', // Input type (text, number, email, etc.)
+          name: "message", // Parameter name (will be used as query param)
+          label: "Your Message", // Label that the user will see
+          type: "text", // Input type (text, number, email, etc.)
           required: true, // Whether it's mandatory or not
-          description: 'Enter the message you want to store on the blockchain',
+          description: "Enter the message you want to store on the blockchain",
         },
         {
-          name: 'amount',
-          label: 'Amount (ETH)',
-          type: 'number',
+          name: "amount",
+          label: "Amount (ETH)",
+          type: "number",
           required: false,
-          description: 'Amount in ETH (optional)',
+          description: "Amount in ETH (optional)",
         },
       ],
     },
@@ -177,20 +191,23 @@ export async function GET(req: NextRequest) {
     // Return with CORS headers
     return NextResponse.json(validated, {
       headers: {
-        'Access-Control-Allow-Origin': '*',
-        'Access-Control-Allow-Methods': 'GET, POST, PUT, DELETE, OPTIONS',
+        "Access-Control-Allow-Origin": "*",
+        "Access-Control-Allow-Methods": "GET, POST, PUT, DELETE, OPTIONS",
       },
     });
   } catch (error) {
-    console.error('Error creating metadata:', error);
-    return NextResponse.json({ error: 'Failed to create metadata' }, { status: 500 });
+    console.error("Error creating metadata:", error);
+    return NextResponse.json({ error: "Failed to create metadata" }, {
+      status: 500,
+    });
   }
 }
 ```
 
 ## Creating the POST Endpoint - Execution
 
-The POST endpoint handles the actual execution of your mini app. It receives user parameters and returns a serialized transaction.
+The POST endpoint handles the actual execution of your mini app. It receives
+user parameters and returns a serialized transaction.
 
 ### 1. Set Up POST Handler
 
@@ -226,12 +243,12 @@ export async function POST(req: NextRequest) {
 
 ```typescript
 // Process data (you can add your business logic here)
-console.log('Message received:', message);
-console.log('Amount received:', amount);
+console.log("Message received:", message);
+console.log("Amount received:", amount);
 
 // Create transaction
 const tx = {
-  to: '0x5ee75a1B1648C023e885E58bD3735Ae273f2cc52', // Destination address
+  to: "0x5ee75a1B1648C023e885E58bD3735Ae273f2cc52", // Destination address
   value: BigInt(amount ? parseFloat(amount) * 1e18 : 1000000), // Value in wei
   chainId: avalancheFuji.id, // Blockchain ID
   // data: "0x..." // You can add contract data here
@@ -271,17 +288,18 @@ const tx = {
 
 ## CORS Handling
 
-To allow your mini app to be used from different domains, you need to handle OPTIONS requests:
+To allow your mini app to be used from different domains, you need to handle
+OPTIONS requests:
 
 ```typescript
 export async function OPTIONS(request: NextRequest) {
   return new NextResponse(null, {
     status: 204,
     headers: {
-      'Access-Control-Allow-Origin': '*',
-      'Access-Control-Allow-Methods': 'GET, POST, PUT, DELETE, OPTIONS',
-      'Access-Control-Allow-Headers':
-        'Content-Type, Authorization, X-CSRF-Token, X-Requested-With, Accept',
+      "Access-Control-Allow-Origin": "*",
+      "Access-Control-Allow-Methods": "GET, POST, PUT, DELETE, OPTIONS",
+      "Access-Control-Allow-Headers":
+        "Content-Type, Authorization, X-CSRF-Token, X-Requested-With, Accept",
     },
   });
 }
@@ -289,7 +307,8 @@ export async function OPTIONS(request: NextRequest) {
 
 ## Testing Your Mini App
 
-Once you've created your GET endpoint, you have several options to test your mini app:
+Once you've created your GET endpoint, you have several options to test your
+mini app:
 
 ### Option 1: Sherry Social App
 
@@ -302,13 +321,15 @@ Once you've created your GET endpoint, you have several options to test your min
 
 The debugger allows you to test your mini app in multiple ways:
 
-1. Go to [https://app.sherry.social/debugger](https://app.sherry.social/debugger)
+1. Go to
+   [https://app.sherry.social/debugger](https://app.sherry.social/debugger)
 
 2. **Option A - URL**: Paste your GET endpoint URL
 3. **Option B - JSON**: Copy and paste your endpoint's JSON response
 4. **Option C - TypeScript**: Paste your TypeScript code directly
 
-**Note**: The debugger is in development and may have bugs. You can report issues directly from the debugger interface.
+**Note**: The debugger is in development and may have bugs. You can report
+issues directly from the debugger interface.
 
 ### Testing Steps:
 
@@ -371,8 +392,11 @@ The debugger allows you to test your mini app in multiple ways:
 You can find a complete example of this tutorial in the following repository:
 [https://github.com/SherryLabs/sherry-example](https://github.com/SherryLabs/sherry-example)
 
-This repository contains all the code needed to implement a functional mini app using Next.js and Sherry SDK.
+This repository contains all the code needed to implement a functional mini app
+using Next.js and Sherry SDK.
 
 ---
 
-Congratulations! You now have your first mini app working with Sherry SDK. You can expand functionality by adding more parameters, custom validations, or integrating with more complex smart contracts.
+Congratulations! You now have your first mini app working with Sherry SDK. You
+can expand functionality by adding more parameters, custom validations, or
+integrating with more complex smart contracts.

--- a/docs/docs/guides/guide-es.mdx
+++ b/docs/docs/guides/guide-es.mdx
@@ -71,8 +71,8 @@ estructura que las plataformas necesitan para renderizar tu aplicación.
 Crea el archivo `app/api/mi-app/route.ts`:
 
 ```typescript
-import { NextRequest, NextResponse } from "next/server";
-import { createMetadata, Metadata, ValidatedMetadata } from "@sherrylinks/sdk";
+import { NextRequest, NextResponse } from 'next/server';
+import { createMetadata, Metadata, ValidatedMetadata } from '@sherrylinks/sdk';
 ```
 
 ### 2. Configurar la Información General
@@ -118,11 +118,11 @@ const metadata: Metadata = {
   // ... información general anterior ...
   actions: [
     {
-      type: "dynamic", // Tipo de acción (siempre "dynamic" para mini apps)
-      label: "Ejecutar Acción", // Texto que aparecerá en el botón
-      description: "Descripción de lo que hace esta acción específica",
+      type: 'dynamic', // Tipo de acción (siempre "dynamic" para mini apps)
+      label: 'Ejecutar Acción', // Texto que aparecerá en el botón
+      description: 'Descripción de lo que hace esta acción específica',
       chains: {
-        source: "fuji", // Blockchain donde se ejecutará (fuji = Avalanche Fuji Testnet)
+        source: 'fuji', // Blockchain donde se ejecutará (fuji = Avalanche Fuji Testnet)
       },
       path: `/api/mi-app`, // Ruta del endpoint POST que manejará la ejecución
       // Los parámetros los definiremos en el siguiente paso
@@ -152,19 +152,18 @@ const metadata: Metadata = {
       // ... configuración anterior ...
       params: [
         {
-          name: "mensaje", // Nombre del parámetro (se usará como query param)
-          label: "Tu Mensaje", // Etiqueta que verá el usuario
-          type: "text", // Tipo de input (text, number, email, etc.)
+          name: 'mensaje', // Nombre del parámetro (se usará como query param)
+          label: 'Tu Mensaje', // Etiqueta que verá el usuario
+          type: 'text', // Tipo de input (text, number, email, etc.)
           required: true, // Si es obligatorio o no
-          description:
-            "Ingresa el mensaje que quieres guardar en la blockchain",
+          description: 'Ingresa el mensaje que quieres guardar en la blockchain',
         },
         {
-          name: "cantidad",
-          label: "Cantidad (ETH)",
-          type: "number",
+          name: 'cantidad',
+          label: 'Cantidad (ETH)',
+          type: 'number',
           required: false,
-          description: "Cantidad en ETH (opcional)",
+          description: 'Cantidad en ETH (opcional)',
         },
       ],
     },
@@ -194,15 +193,18 @@ export async function GET(req: NextRequest) {
     // Retornar con headers CORS
     return NextResponse.json(validated, {
       headers: {
-        "Access-Control-Allow-Origin": "*",
-        "Access-Control-Allow-Methods": "GET, POST, PUT, DELETE, OPTIONS",
+        'Access-Control-Allow-Origin': '*',
+        'Access-Control-Allow-Methods': 'GET, POST, PUT, DELETE, OPTIONS',
       },
     });
   } catch (error) {
-    console.error("Error creando metadata:", error);
-    return NextResponse.json({ error: "Error al crear metadata" }, {
-      status: 500,
-    });
+    console.error('Error creando metadata:', error);
+    return NextResponse.json(
+      { error: 'Error al crear metadata' },
+      {
+        status: 500,
+      },
+    );
   }
 }
 ```
@@ -246,12 +248,12 @@ export async function POST(req: NextRequest) {
 
 ```typescript
 // Procesar los datos (aquí puedes agregar tu lógica de negocio)
-console.log("Mensaje recibido:", mensaje);
-console.log("Cantidad recibida:", cantidad);
+console.log('Mensaje recibido:', mensaje);
+console.log('Cantidad recibida:', cantidad);
 
 // Crear la transacción
 const tx = {
-  to: "0x5ee75a1B1648C023e885E58bD3735Ae273f2cc52", // Dirección destino
+  to: '0x5ee75a1B1648C023e885E58bD3735Ae273f2cc52', // Dirección destino
   value: BigInt(cantidad ? parseFloat(cantidad) * 1e18 : 1000000), // Valor en wei
   chainId: avalancheFuji.id, // ID de la blockchain
   // data: "0x..." // Puedes agregar datos de contrato aquí
@@ -299,10 +301,10 @@ export async function OPTIONS(request: NextRequest) {
   return new NextResponse(null, {
     status: 204,
     headers: {
-      "Access-Control-Allow-Origin": "*",
-      "Access-Control-Allow-Methods": "GET, POST, PUT, DELETE, OPTIONS",
-      "Access-Control-Allow-Headers":
-        "Content-Type, Authorization, X-CSRF-Token, X-Requested-With, Accept",
+      'Access-Control-Allow-Origin': '*',
+      'Access-Control-Allow-Methods': 'GET, POST, PUT, DELETE, OPTIONS',
+      'Access-Control-Allow-Headers':
+        'Content-Type, Authorization, X-CSRF-Token, X-Requested-With, Accept',
     },
   });
 }

--- a/docs/docs/guides/guide-es.mdx
+++ b/docs/docs/guides/guide-es.mdx
@@ -1,6 +1,17 @@
 # Creando Mini Apps con Next.js y Sherry SDK
 
-Esta guía te enseñará paso a paso cómo crear una mini app utilizando Next.js y el SDK de Sherry Links. Las mini apps son aplicaciones dinámicas que pueden ser integradas en diferentes plataformas y permiten a los usuarios interactuar con contratos inteligentes de manera sencilla.
+<iframe
+  style={{ width: '100%', aspectRatio: '16 / 9', border: 'none' }}
+  src="https://www.youtube.com/embed/oHmoJUOgLBA"
+  title="YouTube video player"
+  allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture; web-share"
+  allowfullscreen
+></iframe>
+
+Esta guía te enseñará paso a paso cómo crear una mini app utilizando Next.js y
+el SDK de Sherry Links. Las mini apps son aplicaciones dinámicas que pueden ser
+integradas en diferentes plataformas y permiten a los usuarios interactuar con
+contratos inteligentes de manera sencilla.
 
 ## Tabla de Contenidos
 
@@ -36,7 +47,8 @@ npm install @sherrylinks/sdk viem wagmi
 
 ### 3. Configurar Next.js (Opcional)
 
-Para evitar errores de build con ESLint, puedes deshabilitarlo en `next.config.js`:
+Para evitar errores de build con ESLint, puedes deshabilitarlo en
+`next.config.js`:
 
 ```javascript
 /** @type {import('next').NextConfig} */
@@ -51,15 +63,16 @@ module.exports = nextConfig;
 
 ## Creando el Endpoint GET - Metadata
 
-El endpoint GET es el corazón de tu mini app. Aquí defines toda la información y estructura que las plataformas necesitan para renderizar tu aplicación.
+El endpoint GET es el corazón de tu mini app. Aquí defines toda la información y
+estructura que las plataformas necesitan para renderizar tu aplicación.
 
 ### 1. Crear el Archivo de Ruta
 
 Crea el archivo `app/api/mi-app/route.ts`:
 
 ```typescript
-import { NextRequest, NextResponse } from 'next/server';
-import { createMetadata, Metadata, ValidatedMetadata } from '@sherrylinks/sdk';
+import { NextRequest, NextResponse } from "next/server";
+import { createMetadata, Metadata, ValidatedMetadata } from "@sherrylinks/sdk";
 ```
 
 ### 2. Configurar la Información General
@@ -89,9 +102,11 @@ export async function GET(req: NextRequest) {
 #### Explicación de Campos Generales:
 
 - **url**: URL de tu sitio web o documentación principal
-- **icon**: Imagen que representará tu mini app (debe ser accesible públicamente)
+- **icon**: Imagen que representará tu mini app (debe ser accesible
+  públicamente)
 - **title**: Nombre corto y descriptivo de tu aplicación
-- **baseUrl**: URL donde está corriendo tu aplicación (se construye automáticamente)
+- **baseUrl**: URL donde está corriendo tu aplicación (se construye
+  automáticamente)
 - **description**: Explicación clara de qué hace tu mini app
 
 ### 3. Definir las Acciones
@@ -103,11 +118,11 @@ const metadata: Metadata = {
   // ... información general anterior ...
   actions: [
     {
-      type: 'dynamic', // Tipo de acción (siempre "dynamic" para mini apps)
-      label: 'Ejecutar Acción', // Texto que aparecerá en el botón
-      description: 'Descripción de lo que hace esta acción específica',
+      type: "dynamic", // Tipo de acción (siempre "dynamic" para mini apps)
+      label: "Ejecutar Acción", // Texto que aparecerá en el botón
+      description: "Descripción de lo que hace esta acción específica",
       chains: {
-        source: 'fuji', // Blockchain donde se ejecutará (fuji = Avalanche Fuji Testnet)
+        source: "fuji", // Blockchain donde se ejecutará (fuji = Avalanche Fuji Testnet)
       },
       path: `/api/mi-app`, // Ruta del endpoint POST que manejará la ejecución
       // Los parámetros los definiremos en el siguiente paso
@@ -126,7 +141,8 @@ const metadata: Metadata = {
 
 ### 4. Configurar Parámetros
 
-Los parámetros son los datos que el usuario debe proporcionar. Si no tienen un valor predeterminado, se renderizará un input:
+Los parámetros son los datos que el usuario debe proporcionar. Si no tienen un
+valor predeterminado, se renderizará un input:
 
 ```typescript
 const metadata: Metadata = {
@@ -136,18 +152,19 @@ const metadata: Metadata = {
       // ... configuración anterior ...
       params: [
         {
-          name: 'mensaje', // Nombre del parámetro (se usará como query param)
-          label: 'Tu Mensaje', // Etiqueta que verá el usuario
-          type: 'text', // Tipo de input (text, number, email, etc.)
+          name: "mensaje", // Nombre del parámetro (se usará como query param)
+          label: "Tu Mensaje", // Etiqueta que verá el usuario
+          type: "text", // Tipo de input (text, number, email, etc.)
           required: true, // Si es obligatorio o no
-          description: 'Ingresa el mensaje que quieres guardar en la blockchain',
+          description:
+            "Ingresa el mensaje que quieres guardar en la blockchain",
         },
         {
-          name: 'cantidad',
-          label: 'Cantidad (ETH)',
-          type: 'number',
+          name: "cantidad",
+          label: "Cantidad (ETH)",
+          type: "number",
           required: false,
-          description: 'Cantidad en ETH (opcional)',
+          description: "Cantidad en ETH (opcional)",
         },
       ],
     },
@@ -177,20 +194,23 @@ export async function GET(req: NextRequest) {
     // Retornar con headers CORS
     return NextResponse.json(validated, {
       headers: {
-        'Access-Control-Allow-Origin': '*',
-        'Access-Control-Allow-Methods': 'GET, POST, PUT, DELETE, OPTIONS',
+        "Access-Control-Allow-Origin": "*",
+        "Access-Control-Allow-Methods": "GET, POST, PUT, DELETE, OPTIONS",
       },
     });
   } catch (error) {
-    console.error('Error creando metadata:', error);
-    return NextResponse.json({ error: 'Error al crear metadata' }, { status: 500 });
+    console.error("Error creando metadata:", error);
+    return NextResponse.json({ error: "Error al crear metadata" }, {
+      status: 500,
+    });
   }
 }
 ```
 
 ## Creando el Endpoint POST - Ejecución
 
-El endpoint POST maneja la ejecución real de tu mini app. Recibe los parámetros del usuario y devuelve una transacción serializada.
+El endpoint POST maneja la ejecución real de tu mini app. Recibe los parámetros
+del usuario y devuelve una transacción serializada.
 
 ### 1. Configurar el Handler POST
 
@@ -226,12 +246,12 @@ export async function POST(req: NextRequest) {
 
 ```typescript
 // Procesar los datos (aquí puedes agregar tu lógica de negocio)
-console.log('Mensaje recibido:', mensaje);
-console.log('Cantidad recibida:', cantidad);
+console.log("Mensaje recibido:", mensaje);
+console.log("Cantidad recibida:", cantidad);
 
 // Crear la transacción
 const tx = {
-  to: '0x5ee75a1B1648C023e885E58bD3735Ae273f2cc52', // Dirección destino
+  to: "0x5ee75a1B1648C023e885E58bD3735Ae273f2cc52", // Dirección destino
   value: BigInt(cantidad ? parseFloat(cantidad) * 1e18 : 1000000), // Valor en wei
   chainId: avalancheFuji.id, // ID de la blockchain
   // data: "0x..." // Puedes agregar datos de contrato aquí
@@ -271,17 +291,18 @@ const tx = {
 
 ## Manejo de CORS
 
-Para permitir que tu mini app sea utilizada desde diferentes dominios, necesitas manejar las peticiones OPTIONS:
+Para permitir que tu mini app sea utilizada desde diferentes dominios, necesitas
+manejar las peticiones OPTIONS:
 
 ```typescript
 export async function OPTIONS(request: NextRequest) {
   return new NextResponse(null, {
     status: 204,
     headers: {
-      'Access-Control-Allow-Origin': '*',
-      'Access-Control-Allow-Methods': 'GET, POST, PUT, DELETE, OPTIONS',
-      'Access-Control-Allow-Headers':
-        'Content-Type, Authorization, X-CSRF-Token, X-Requested-With, Accept',
+      "Access-Control-Allow-Origin": "*",
+      "Access-Control-Allow-Methods": "GET, POST, PUT, DELETE, OPTIONS",
+      "Access-Control-Allow-Headers":
+        "Content-Type, Authorization, X-CSRF-Token, X-Requested-With, Accept",
     },
   });
 }
@@ -289,7 +310,8 @@ export async function OPTIONS(request: NextRequest) {
 
 ## Probando tu Mini App
 
-Una vez que hayas creado tu endpoint GET, tienes varias opciones para probar tu mini app:
+Una vez que hayas creado tu endpoint GET, tienes varias opciones para probar tu
+mini app:
 
 ### Opción 1: Sherry Social App
 
@@ -308,7 +330,8 @@ El debugger te permite probar tu mini app de múltiples maneras:
 3. **Opción B - JSON**: Copia y pega la respuesta JSON de tu endpoint
 4. **Opción C - TypeScript**: Pega directamente tu código TypeScript
 
-**Nota**: El debugger está en desarrollo y puede tener bugs. Puedes reportar problemas directamente desde la interfaz del debugger.
+**Nota**: El debugger está en desarrollo y puede tener bugs. Puedes reportar
+problemas directamente desde la interfaz del debugger.
 
 ### Pasos para Probar:
 
@@ -349,8 +372,10 @@ El debugger te permite probar tu mini app de múltiples maneras:
 
 ### Error: "Parameter required"
 
-- Asegúrate de que los parámetros requeridos estén marcados como `required: true`
-- Verifica que los nombres de los parámetros coincidan entre la metadata y el POST
+- Asegúrate de que los parámetros requeridos estén marcados como
+  `required: true`
+- Verifica que los nombres de los parámetros coincidan entre la metadata y el
+  POST
 
 ### La mini app no se renderiza correctamente
 
@@ -360,7 +385,8 @@ El debugger te permite probar tu mini app de múltiples maneras:
 
 ### Errores de serialización de transacciones
 
-- Verifica que los valores estén en el formato correcto (BigInt para valores de wei)
+- Verifica que los valores estén en el formato correcto (BigInt para valores de
+  wei)
 - Asegúrate de que el chainId sea válido
 - Revisa que la dirección 'to' sea una dirección Ethereum válida
 
@@ -368,11 +394,15 @@ El debugger te permite probar tu mini app de múltiples maneras:
 
 ### Español
 
-Puedes encontrar un ejemplo completo de este tutorial en el siguiente repositorio:
+Puedes encontrar un ejemplo completo de este tutorial en el siguiente
+repositorio:
 [https://github.com/SherryLabs/sherry-example](https://github.com/SherryLabs/sherry-example)
 
-Este repositorio contiene todo el código necesario para implementar una mini app funcional usando Next.js y Sherry SDK.
+Este repositorio contiene todo el código necesario para implementar una mini app
+funcional usando Next.js y Sherry SDK.
 
 ---
 
-¡Felicidades! Ya tienes tu primera mini app funcionando con Sherry SDK. Puedes expandir la funcionalidad agregando más parámetros, validaciones personalizadas, o integrando con contratos inteligentes más complejos.
+¡Felicidades! Ya tienes tu primera mini app funcionando con Sherry SDK. Puedes
+expandir la funcionalidad agregando más parámetros, validaciones personalizadas,
+o integrando con contratos inteligentes más complejos.


### PR DESCRIPTION
This PR adds an embedded YouTube video for each guide (English/Spanish) in the documentation, since those video tutorials were posted in the Sherry YouTube channel but not referenced in the website itself. This makes the developer onboarding easier for those who prefer video learning material.

Additionally, when following the README developer setup guide I noticed there was a `yarn install` missing before starting the Docusaurus server with `yarn start` so I added it and formatted the README markdown with Prettier for readability.

## YouTube tutorials added to documentation
- English: https://www.youtube.com/watch?v=Aq6gqxjEoxo
- Spanish: https://www.youtube.com/watch?v=oHmoJUOgLBA

## Work done
- Format with Prettier for consistency and readability
- Add YouTube `iframe` tags in documentation for project guides in English and Spanish, referencing tutorials from the Sherry YouTube channel

## Additional considerations
The YouTube video is so helpful! Many concepts well explained. But the documentation itself still could benefit from
- better structure, dividing guides into smaller topics or steps
- explicitness (many code examples either took for granted being placed in a certain file location or segment or were redundant and could be stated in a single snippet for clearness)
- would be useful to reference the specific GitHub URL with the project source code, or even better, a StackBlitz template

Keep up the great work!