### PR TITLE
improving docs

### DIFF
--- a/docs/docs/getting-started/keyconcepts.md
+++ b/docs/docs/getting-started/keyconcepts.md
@@ -15,7 +15,6 @@ import { createMetadata, Metadata } from '@sherrylinks/sdk';
 
 interface Metadata {
   url: string;
-  icon: string;
   title: string;
   description: string;
   actions: Action[];
@@ -26,23 +25,24 @@ interface Metadata {
 1. **url\***: The url that will be shown.<br/>
    Example: "https://sherry.social/links"
 
-2. **icon\***: URL of the trigger's visual representation. <br/>
-   Example: "https://mi-image.com"
-
-3. **title\***: The title displayed in the user interface. <br/>
+2. **title\***: The title displayed in the user interface. <br/>
    Example: "sherry.social"
 
-4. **description\***: A short explanation of the trigger's purpose. <br/>
+3. **description\***: A short explanation of the trigger's purpose. <br/>
    Example: "Claim your early supporter badge"
 
-5. **baseurl** : solo depende de si usas dynamic actions
+4. **baseurl** : solo depende de si usas dynamic actions
 
-6. **actions\***: <br/>
+5. **actions\***: <br/>
    Puede variar dependiendo de que action se vaya a usar.
 
 # Understanding Actions and Parameters
 
 Actions are the core of triggers, defining what a user can do. Parameters specify the inputs required for those actions.
+
+:::info Action Flows - In Final Development
+Action Flows are currently in their final development stage and have not yet been released. This functionality will be available in upcoming versions.
+:::
 
 ## Actions
 
@@ -68,7 +68,6 @@ import { Metadata } from '@sherrylinks/sdk';
 
 const nftMintAction: Metadata = {
   url: 'https://myapp.example',
-  icon: 'https://example.com/icon.png',
   title: 'NFT Minter',
   description: 'Mint awesome NFTs',
   actions: [
@@ -99,7 +98,6 @@ For sending native tokens between addresses.
 ```typescript
 const transferAction: Metadata = {
   url: 'https://myapp.example',
-  icon: 'https://example.com/icon.png',
   title: 'Send AVAX',
   description: 'Quick AVAX transfer',
   actions: [
@@ -121,7 +119,6 @@ For making HTTP requests to external APIs.
 ```typescript
 const httpActionExample = {
   url: 'https://myapp.example',
-  icon: 'https://example.com/icon.png',
   title: 'Submit Feedback',
   description: 'Send feedback to our API',
   actions: [
@@ -159,7 +156,6 @@ For flexible actions where logic is computed server-side.
 ```typescript
 const dynamicAction: Metadata = {
   url: 'https://myapp.example',
-  icon: 'https://example.com/icon.png',
   title: 'Dynamic Swap',
   description: 'Smart token swapping',
   baseUrl: 'https://myapp.example',
@@ -185,6 +181,10 @@ const dynamicAction: Metadata = {
 #### ActionFlow
 
 For multi-step processes with conditional logic.
+
+:::info Coming Soon
+ActionFlow functionality is currently in its final development stage and will be available in upcoming releases.
+:::
 
 ```typescript
 import { ActionFlow } from '@sherrylinks/sdk';
@@ -261,7 +261,7 @@ Each type comes with specific validation properties. Refer to the [detailed para
 Use predefined templates for common parameters to ensure consistency and reduce boilerplate.
 
 ```typescript
-import { PARAM_TEMPLATES, createParameter } from '@sherrylabs/sdk'; // Assuming correct import path
+import { PARAM_TEMPLATES, createParameter } from '@sherrylinks/sdk'; // Assuming correct import path
 
 // Address parameter
 const recipientParam = createParameter(PARAM_TEMPLATES.ADDRESS, {

--- a/docs/docs/sdk/creating-miniapps.md
+++ b/docs/docs/sdk/creating-miniapps.md
@@ -3,32 +3,32 @@
 sidebar_position: 2
 ---
 
-# Creating Mini-Apps
+# Creating Triggers
 
-The heart of a Sherry mini-app is the `Metadata` object. This object defines how your mini-app looks and what it does.
+The heart of a Sherry trigger is the `Metadata` object. This object defines how your trigger looks and what it does.
 
 ## The `Metadata` Interface
 
 ```typescript
 // src/interface/metadata.ts
 export interface Metadata {
-  url: string; // Unique identifying URL for your mini-app
+  url: string; // Unique identifying URL for your trigger
   icon: string; // URL of the icon to display
-  title: string; // Main title of the mini-app
+  title: string; // Main title of the trigger
   description: string; // Short description
-  actions: Action[]; // Array of actions the mini-app can perform
+  actions: Action[]; // Array of actions the trigger can perform
 }
 ```
 
 - `url`: Must be a unique URL that identifies your application. Using a URL under your control is recommended.
-- `icon`: A URL to an image (preferably PNG or SVG) representing your mini-app.
+- `icon`: A URL to an image (preferably PNG or SVG) representing your trigger.
 - `title`: A concise and descriptive title.
-- `description`: A brief explanation of what the mini-app does.
+- `description`: A brief explanation of what the trigger does.
 - `actions`: An array containing one or more action definitions. These can be `BlockchainActionMetadata`, `TransferAction`, `HttpAction`, or `ActionFlow`.
 
 ## Basic Example
 
-Here's a simple example of `Metadata` for a mini-app that allows sending 0.1 AVAX to a fixed address:
+Here's a simple example of `Metadata` for a trigger that allows sending 0.1 AVAX to a fixed address:
 
 ```typescript
 import { Metadata, TransferAction } from '@sherrylinks/sdk';


### PR DESCRIPTION
This pull request updates the documentation for the Sherry SDK, focusing on the `Metadata` interface and its usage in triggers. The most significant changes include the removal of the `icon` property from the `Metadata` interface, the addition of new informational notes about upcoming features, and the rebranding of "mini-apps" to "triggers" across the documentation.

### Updates to the `Metadata` Interface:
* Removed the `icon` property from the `Metadata` interface and all related examples in `docs/docs/getting-started/keyconcepts.md`. This simplifies the interface and aligns it with updated SDK requirements. [[1]](diffhunk://#diff-e1321175c972ef75741a4f7ecf36995c9e8477a4dfb8cf28c13ef04ca0369f21L18) [[2]](diffhunk://#diff-e1321175c972ef75741a4f7ecf36995c9e8477a4dfb8cf28c13ef04ca0369f21L71) [[3]](diffhunk://#diff-e1321175c972ef75741a4f7ecf36995c9e8477a4dfb8cf28c13ef04ca0369f21L102) [[4]](diffhunk://#diff-e1321175c972ef75741a4f7ecf36995c9e8477a4dfb8cf28c13ef04ca0369f21L124) [[5]](diffhunk://#diff-e1321175c972ef75741a4f7ecf36995c9e8477a4dfb8cf28c13ef04ca0369f21L162)

### Informational Notes:
* Added notes about the upcoming release of `ActionFlow` functionality in `docs/docs/getting-started/keyconcepts.md`, highlighting features currently under development.

### Documentation Rebranding:
* Rebranded "mini-apps" to "triggers" throughout `docs/docs/sdk/creating-miniapps.md` to reflect updated terminology and improve clarity.

### Minor Fixes:
* Corrected the import path for `PARAM_TEMPLATES` in `docs/docs/getting-started/keyconcepts.md`.