### PR TITLE
Feature Adding Base and Mantle to SDK

### DIFF
--- a/docs/docs/core-concepts/chains.md
+++ b/docs/docs/core-concepts/chains.md
@@ -347,18 +347,18 @@ The Sherry SDK has transitioned from using string-based chain names to numeric c
 
 ### Chain ID Reference Table
 
-| Network                | Chain ID   | Description                       |
-| ---------------------- | ---------- | --------------------------------- |
-| Ethereum Mainnet       | `1`        | The original Ethereum network     |
-| Ethereum Sepolia       | `11155111` | Ethereum's recommended testnet    |
-| Avalanche C-Chain      | `43114`    | Avalanche mainnet                 |
-| Avalanche Fuji         | `43113`    | Avalanche's testnet               |
-| Celo Mainnet           | `42220`    | Celo's main network               |
-| Celo Alfajores         | `44787`    | Celo's testnet                    |
-| Mantle Mainnet         | `5000`     | Mantle's main network             |
-| Mantle Sepolia Testnet | `5003`     | Mantle's testnet                  |
-| Base Mainnet           | `8453`     | Base's main network               |
-| Base Sepolia Testnet   | `84532`    | Base's testnet                    |
+| Network                | Chain ID   | Description                    |
+| ---------------------- | ---------- | ------------------------------ |
+| Ethereum Mainnet       | `1`        | The original Ethereum network  |
+| Ethereum Sepolia       | `11155111` | Ethereum's recommended testnet |
+| Avalanche C-Chain      | `43114`    | Avalanche mainnet              |
+| Avalanche Fuji         | `43113`    | Avalanche's testnet            |
+| Celo Mainnet           | `42220`    | Celo's main network            |
+| Celo Alfajores         | `44787`    | Celo's testnet                 |
+| Mantle Mainnet         | `5000`     | Mantle's main network          |
+| Mantle Sepolia Testnet | `5003`     | Mantle's testnet               |
+| Base Mainnet           | `8453`     | Base's main network            |
+| Base Sepolia Testnet   | `84532`    | Base's testnet                 |
 
 ### Quick Migration Guide
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@sherrylinks/sdk",
-  "version": "2.25.21-beta.1",
+  "version": "2.26.21-beta.1",
   "description": "SDK for Sherry Links",
   "main": "dist/index.js",
   "module": "dist/index.esm.js",

--- a/src/interface/chains.ts
+++ b/src/interface/chains.ts
@@ -9,7 +9,7 @@ import {
     mantle,
     mantleSepoliaTestnet,
     base,
-    baseSepolia
+    baseSepolia,
 } from 'viem/chains';
 
 export const VALID_CHAIN_IDS = [
@@ -23,7 +23,6 @@ export const VALID_CHAIN_IDS = [
     mantleSepoliaTestnet.id, // Mantle Sepolia Testnet
     base.id, // Base Mainnet
     baseSepolia.id, // Base Sepolia Testnet
-
 ];
 
 export type ChainId = (typeof VALID_CHAIN_IDS)[number];


### PR DESCRIPTION
This pull request introduces support for two new blockchain networks, Mantle and Base, alongside their respective testnets, and enhances chain-related utilities in the SDK. The changes include updates to documentation, type definitions, and utility functions to ensure seamless integration and validation for these new chains.

### New Chain Support

* Added Mantle Mainnet (`5000`) and Mantle Sepolia Testnet (`5003`) to the supported chains list in `docs/docs/core-concepts/chains.md` and `src/interface/chains.ts`. Updated chain IDs, names, and descriptions accordingly. [[1]](diffhunk://#diff-18e4e50ac2475ae447718b3c0006a8b23162a7793656156952bd4397eacd4b4eR24-R36) [[2]](diffhunk://#diff-18e4e50ac2475ae447718b3c0006a8b23162a7793656156952bd4397eacd4b4eR81-R94) [[3]](diffhunk://#diff-18e4e50ac2475ae447718b3c0006a8b23162a7793656156952bd4397eacd4b4eR115-R126) [[4]](diffhunk://#diff-080d2c3b24065a67d3d8973c1da34ca995f0529ac5021b17b931878cdc21d193R9-R25) [[5]](diffhunk://#diff-080d2c3b24065a67d3d8973c1da34ca995f0529ac5021b17b931878cdc21d193R37-R40) [[6]](diffhunk://#diff-080d2c3b24065a67d3d8973c1da34ca995f0529ac5021b17b931878cdc21d193R58-R65)
* Added Base Mainnet (`8453`) and Base Sepolia Testnet (`84532`) with similar updates to supported chains, chain IDs, names, and descriptions. [[1]](diffhunk://#diff-18e4e50ac2475ae447718b3c0006a8b23162a7793656156952bd4397eacd4b4eR24-R36) [[2]](diffhunk://#diff-18e4e50ac2475ae447718b3c0006a8b23162a7793656156952bd4397eacd4b4eR81-R94) [[3]](diffhunk://#diff-18e4e50ac2475ae447718b3c0006a8b23162a7793656156952bd4397eacd4b4eR115-R126) [[4]](diffhunk://#diff-080d2c3b24065a67d3d8973c1da34ca995f0529ac5021b17b931878cdc21d193R9-R25) [[5]](diffhunk://#diff-080d2c3b24065a67d3d8973c1da34ca995f0529ac5021b17b931878cdc21d193R37-R40) [[6]](diffhunk://#diff-080d2c3b24065a67d3d8973c1da34ca995f0529ac5021b17b931878cdc21d193R58-R65)

### Documentation Updates

* Updated the chain reference table in `docs/docs/core-concepts/chains.md` to include Mantle and Base networks and their testnets.
* Removed outdated references to Base from future chain support announcements.

### SDK Enhancements

* Added utility functions `isChainSupported` and `getChainInfo` in `src/interface/chains.ts` for chain validation and retrieval of chain information by name or ID.
* Enhanced `chainUtils` with methods for validating chains and retrieving complete chain information by name or ID.

### Miscellaneous

* Updated the SDK version in `package.json` to `2.26.21-beta.1`.