### PR TITLE
fix: increment version to 2.26.23-beta.1 in package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@sherrylinks/sdk",
-  "version": "2.26.22-beta.1",
+  "version": "2.26.23-beta.1",
   "description": "SDK for Sherry Links",
   "main": "dist/index.js",
   "module": "dist/index.esm.js",


### PR DESCRIPTION
This pull request includes a minor version bump for the `@sherrylinks/sdk` package. The change updates the version from `2.26.22-beta.1` to `2.26.23-beta.1` in the `package.json` file.